### PR TITLE
Fix undefined index in session_varchar_allow

### DIFF
--- a/globals.php
+++ b/globals.php
@@ -113,7 +113,7 @@ function session_varchar_empty($filthy) {
 
 function session_varchar_allow($filthy) {
   if ( !isset($_SESSION["$filthy"]) ) {
-    $session_var = $_SESSION["$filthy"];
+    $session_var = "";
   }
   elseif ( empty($_SESSION["$filthy"]) ) {
     $session_var = "";


### PR DESCRIPTION
## Summary
- avoid undefined index in `session_varchar_allow`

## Testing
- `php -l globals.php` *(fails: `php` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683fef14d4208322b90959f733b3c819